### PR TITLE
[SITE-5158] Update name and zip file name

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ patches and features.
 
 ## Using the issue tracker
 
-The [issue tracker](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues) is
+The [issue tracker](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues) is
 the preferred channel for [bug reports](#bug-reports), [features requests](#feature-requests)
 and [submitting pull requests](#pull-requests), but please respect the following
 restrictions:
@@ -40,7 +40,7 @@ them:
 - `question` - General support/questions issue bucket.
 
 For a complete look at our labels, see
-the [project labels page](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/labels).
+the [project labels page](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/labels).
 
 ## Bug reports
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,13 +6,13 @@ labels: bug
 
 Before opening:
 
-- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues?utf8=%E2%9C%93&q=is%3Aissue)
+- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues?utf8=%E2%9C%93&q=is%3Aissue)
 - Validate
-  and [lint](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/master/phpcs.xml) any PHP
+  and [lint](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/master/phpcs.xml) any PHP
   code to avoid
   common problems
 - Read
-  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/CONTRIBUTING.md)
+  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/.github/CONTRIBUTING.md)
 
 Bug reports must include:
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,9 +6,9 @@ labels: feature
 
 Before opening:
 
-- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues?utf8=%E2%9C%93&q=is%3Aissue)
+- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues?utf8=%E2%9C%93&q=is%3Aissue)
 - Read
-  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/master/.github/CONTRIBUTING.md)
+  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/master/.github/CONTRIBUTING.md)
 
 Feature requests must include:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 
 - [ ] I've tested the code.
 - [ ] My code follows the repository code
-  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
+  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/phpcs.xml/ -->
 - [ ] My code follows the accessibility
   standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
 - [ ] My code follows the PHP DocBlock documentation

--- a/.github/release.sh
+++ b/.github/release.sh
@@ -16,7 +16,9 @@ INCLUDES=(
 
 # Determine repository name from the current directory.
 REPO=$(basename "$(pwd)")
-ZIP="${REPO}.zip"
+# Zip file to match plugin name rather then repo name
+PLUGIN_NAME="pantheon-content-publisher"
+ZIP="${PLUGIN_NAME}.zip"
 
 echo "Starting build process for $REPO..."
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ bin/
 *.code-workspace
 .idea
 pantheon-content-publisher-for-wordpress.zip
+pantheon-content-publisher-wordpress.zip
+pantheon-content-publisher.zip
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@
 <p align="center">
   <i>Publish WordPress content from Google Docs with Pantheon Content Cloud.</i>
   <br>
-  <a href="https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues/new?template=bug_report.md&labels=bug">Report bug</a>
+  <a href="https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues/new?template=bug_report.md&labels=bug">Report bug</a>
   ·
-  <a href="https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues/new?template=feature_request.md&labels=feature">Request feature</a>
+  <a href="https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues/new?template=feature_request.md&labels=feature">Request feature</a>
   ·
   <a href="https://pcc.pantheon.io/docs" target="_blank">Check out PCC Docs</a>
 </p>
 
 <div align="center">
 
-[![Style Lint](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/actions/workflows/php-style-lint.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/actions/workflows/php-style-lint.yml)
-[![PHP Compatibility 8.x](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/actions/workflows/php-version-compatibility.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/actions/workflows/php-version-compatibility.yml)
+[![Style Lint](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/actions/workflows/php-style-lint.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/actions/workflows/php-style-lint.yml)
+[![PHP Compatibility 8.x](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/actions/workflows/php-version-compatibility.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/actions/workflows/php-version-compatibility.yml)
 
 </div>
 
@@ -42,11 +42,11 @@
 
 This is a WordPress plugin. It can be installed via the usual WordPress Dashboard workflow.
 
-- [Download the latest release.](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/releases/)
+- [Download the latest release.](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/releases/)
 
 or
 
-- Clone the repo: `git clone https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress.git` in
+- Clone the repo: `git clone https://github.com/pantheon-systems/pantheon-content-publisher-wordpress.git` in
   your `wp-content/plugins`
   folder
 
@@ -69,8 +69,8 @@ below_**
 
 This repository takes advantage of the following workflows to automate the release & testing processes:
 
-- [PHPCS](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/workflows/php-style-lint.yml)
-- [PHPCompatibility](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/workflows/php-version-compatibility.yml)
+- [PHPCS](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/.github/workflows/php-style-lint.yml)
+- [PHPCompatibility](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/.github/workflows/php-version-compatibility.yml)
 - [Release Drafter](https://github.com/marketplace/actions/release-drafter)
 - [PR Labeler](https://github.com/marketplace/actions/pr-labeler)
 - [A custom workflow that builds release artifacts](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/workflows/release-artifact.yml)
@@ -96,9 +96,9 @@ Pantheon Content Publisher is dependent on:
 ## Bugs and feature requests
 
 Have a bug or a feature request? Please first read
-the [issue guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/CONTRIBUTING.md#using-the-issue-tracker)
+the [issue guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/.github/CONTRIBUTING.md#using-the-issue-tracker)
 and search for existing and closed issues. If your problem or idea is not addressed
-yet, [please open a new issue](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues/new).
+yet, [please open a new issue](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues/new).
 
 ## Documentation
 
@@ -113,5 +113,5 @@ adhere to those rules whenever possible.
 ## Changelog
 
 You may find changelogs for each version of Pantheon Content Publisher released
-in [the Releases section](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/releases) of this
+in [the Releases section](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/releases) of this
 repository.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
   description: A PCC publisher module for publishing wordpress content
   annotations:
     pantheon.io/service-catalog/subdir: /
-    github.com/project-slug: pantheon-systems/pantheon-content-publisher-for-wordpress
+    github.com/project-slug: pantheon-systems/pantheon-content-publisher-wordpress
     github.com/team-slug: pantheon-systems/pcc
 spec:
   type: library

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pantheon-systems/pantheon-content-publisher-for-wordpress",
+  "name": "pantheon-systems/pantheon-content-publisher-wordpress",
   "type": "wordpress-plugin",
   "description": "Publish WordPress content from Google Docs with Pantheon Content Cloud.",
   "keywords": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pantheon-content-publisher-for-wordpress",
+  "name": "pantheon-content-publisher",
   "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pantheon-content-publisher-for-wordpress",
+      "name": "pantheon-content-publisher",
       "version": "1.2.6",
       "dependencies": {
         "@pantheon-systems/pcc-sdk-core": "3.11.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pantheon-content-publisher-for-wordpress",
+  "name": "pantheon-content-publisher",
   "version": "1.2.6",
   "description": "Publish WordPress content from Google Docs with Pantheon Content Cloud.",
   "scripts": {

--- a/pantheon-content-publisher-for-wordpress.php
+++ b/pantheon-content-publisher-for-wordpress.php
@@ -5,7 +5,7 @@
 /**
  * Plugin Name: Pantheon Content Publisher
  * Description: Publish WordPress content from Google Docs with Pantheon Content Cloud.
- * Plugin URI: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/
+ * Plugin URI: https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/
  * Author: Pantheon
  * Author URI: https://pantheon.io
  * Version: 1.2.6


### PR DESCRIPTION
We are updating the plugin name and the GitHub repo name.

Updating slug and names:
Github: pantheon-content-publisher-wordpress
WP Plugin: pantheon-content-publisher

To match WordPress.org rules on plugins' slug, we are removing the slug "-for-wordpress" from the plugin.
We also need to keep the suffix "-wordpress" in the GitHub repository to avoid confusion amongst the different Pantheon Content Publisher repositories.