### PR TITLE
[SITE-5164] wp submission - update repo url

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ patches and features.
 
 ## Using the issue tracker
 
-The [issue tracker](https://github.com/pantheon-systems/pantheon-content-publisher/issues) is
+The [issue tracker](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues) is
 the preferred channel for [bug reports](#bug-reports), [features requests](#feature-requests)
 and [submitting pull requests](#pull-requests), but please respect the following
 restrictions:
@@ -40,7 +40,7 @@ them:
 - `question` - General support/questions issue bucket.
 
 For a complete look at our labels, see
-the [project labels page](https://github.com/pantheon-systems/pantheon-content-publisher/labels).
+the [project labels page](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/labels).
 
 ## Bug reports
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,13 +6,13 @@ labels: bug
 
 Before opening:
 
-- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher/issues?utf8=%E2%9C%93&q=is%3Aissue)
+- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues?utf8=%E2%9C%93&q=is%3Aissue)
 - Validate
-  and [lint](https://github.com/pantheon-systems/pantheon-content-publisher/blob/master/phpcs.xml) any PHP
+  and [lint](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/master/phpcs.xml) any PHP
   code to avoid
   common problems
 - Read
-  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/CONTRIBUTING.md)
+  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/.github/CONTRIBUTING.md)
 
 Bug reports must include:
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,9 +6,9 @@ labels: feature
 
 Before opening:
 
-- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher/issues?utf8=%E2%9C%93&q=is%3Aissue)
+- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues?utf8=%E2%9C%93&q=is%3Aissue)
 - Read
-  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher/blob/master/.github/CONTRIBUTING.md)
+  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/master/.github/CONTRIBUTING.md)
 
 Feature requests must include:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 
 - [ ] I've tested the code.
 - [ ] My code follows the repository code
-  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/phpcs.xml/ -->
+  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/phpcs.xml/ -->
 - [ ] My code follows the accessibility
   standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
 - [ ] My code follows the PHP DocBlock documentation

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,7 +31,7 @@ version-resolver:
       - 'patch'
   default: patch
 template: |
-  ## [v$RESOLVED_VERSION(####-##-##)](https://github.com/pantheon-systems/pantheon-content-publisher/compare/$PREVIOUS_TAG...$RESOLVED_VERSION)
+  ## [v$RESOLVED_VERSION(####-##-##)](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/compare/$PREVIOUS_TAG...$RESOLVED_VERSION)
 
   $CHANGES
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@
 <p align="center">
   <i>Publish WordPress content from Google Docs with Pantheon Content Cloud.</i>
   <br>
-  <a href="https://github.com/pantheon-systems/pantheon-content-publisher/issues/new?template=bug_report.md&labels=bug">Report bug</a>
+  <a href="https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues/new?template=bug_report.md&labels=bug">Report bug</a>
   ·
-  <a href="https://github.com/pantheon-systems/pantheon-content-publisher/issues/new?template=feature_request.md&labels=feature">Request feature</a>
+  <a href="https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues/new?template=feature_request.md&labels=feature">Request feature</a>
   ·
   <a href="https://pcc.pantheon.io/docs" target="_blank">Check out PCC Docs</a>
 </p>
 
 <div align="center">
 
-[![Style Lint](https://github.com/pantheon-systems/pantheon-content-publisher/actions/workflows/php-style-lint.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher/actions/workflows/php-style-lint.yml)
-[![PHP Compatibility 8.x](https://github.com/pantheon-systems/pantheon-content-publisher/actions/workflows/php-version-compatibility.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher/actions/workflows/php-version-compatibility.yml)
+[![Style Lint](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/actions/workflows/php-style-lint.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/actions/workflows/php-style-lint.yml)
+[![PHP Compatibility 8.x](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/actions/workflows/php-version-compatibility.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/actions/workflows/php-version-compatibility.yml)
 
 </div>
 
@@ -42,17 +42,17 @@
 
 This is a WordPress plugin. It can be installed via the usual WordPress Dashboard workflow.
 
-- [Download the latest release.](https://github.com/pantheon-systems/pantheon-content-publisher/releases/)
+- [Download the latest release.](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/releases/)
 
 or
 
-- Clone the repo: `git clone https://github.com/pantheon-systems/pantheon-content-publisher.git` in
+- Clone the repo: `git clone https://github.com/pantheon-systems/pantheon-content-publisher-wordpress.git` in
   your `wp-content/plugins`
   folder
 
 **_or soon_**
 
-- Install via Composer: `composer require pantheon-systems/pantheon-content-publisher`
+- Install via Composer: `composer require pantheon-systems/pantheon-content-publisher-wordpress`
 
 **_If installing from source, make sure to follow the build instructions in the [Development](#development) section
 below_**
@@ -62,18 +62,18 @@ below_**
 1. `composer i && npm i` to install dependencies.
 2. `npm run watch` / `npm run dev` / `npm run prod` to build assets.
 3. Read through
-   our [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/CONTRIBUTING.md)
+   our [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/.github/CONTRIBUTING.md)
    for additional information. Included are directions for opening issues, coding standards and miscellaneous notes.
 
 ## Repository Actions
 
 This repository takes advantage of the following workflows to automate the release & testing processes:
 
-- [PHPCS](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/workflows/php-style-lint.yml)
-- [PHPCompatibility](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/workflows/php-version-compatibility.yml)
+- [PHPCS](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/.github/workflows/php-style-lint.yml)
+- [PHPCompatibility](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/.github/workflows/php-version-compatibility.yml)
 - [Release Drafter](https://github.com/marketplace/actions/release-drafter)
 - [PR Labeler](https://github.com/marketplace/actions/pr-labeler)
-- [A custom workflow that builds release artifacts](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/workflows/release-artifact.yml)
+- [A custom workflow that builds release artifacts](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/.github/workflows/release-artifact.yml)
 
 These workflows will build a release draft and keep it up-to-date as new PRs are merged. Once a release is published, a
 ready-to-install zip file will be generated and attached to the newly-published release.
@@ -96,9 +96,9 @@ Pantheon Content Publisher is dependent on:
 ## Bugs and feature requests
 
 Have a bug or a feature request? Please first read
-the [issue guidelines](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/CONTRIBUTING.md#using-the-issue-tracker)
+the [issue guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/blob/primary/.github/CONTRIBUTING.md#using-the-issue-tracker)
 and search for existing and closed issues. If your problem or idea is not addressed
-yet, [please open a new issue](https://github.com/pantheon-systems/pantheon-content-publisher/issues/new).
+yet, [please open a new issue](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/issues/new).
 
 ## Documentation
 
@@ -113,5 +113,5 @@ adhere to those rules whenever possible.
 ## Changelog
 
 You may find changelogs for each version of Pantheon Content Publisher released
-in [the Releases section](https://github.com/pantheon-systems/pantheon-content-publisher/releases) of this
+in [the Releases section](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/releases) of this
 repository.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
   description: A PCC publisher module for publishing wordpress content
   annotations:
     pantheon.io/service-catalog/subdir: /
-    github.com/project-slug: pantheon-systems/pantheon-content-publisher
+    github.com/project-slug: pantheon-systems/pantheon-content-publisher-wordpress
     github.com/team-slug: pantheon-systems/pcc
 spec:
   type: library

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pantheon-systems/pantheon-content-publisher",
+  "name": "pantheon-systems/pantheon-content-publisher-wordpress",
   "type": "wordpress-plugin",
   "description": "Publish WordPress content from Google Docs with Pantheon Content Cloud.",
   "keywords": [

--- a/pantheon-content-publisher.php
+++ b/pantheon-content-publisher.php
@@ -5,7 +5,7 @@
 /**
  * Plugin Name: Pantheon Content Publisher
  * Description: Publish WordPress content from Google Docs with Pantheon Content Cloud.
- * Plugin URI: https://github.com/pantheon-systems/pantheon-content-publisher/
+ * Plugin URI: https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/
  * Author: Pantheon
  * Author URI: https://pantheon.io
  * Version: 1.2.6


### PR DESCRIPTION
Change the URI to the new GitHub repo name: https://github.com/pantheon-systems/pantheon-content-publisher-wordpress