### PR TITLE
[SITE-5304] Include composer.json in release asset

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -12,6 +12,7 @@ INCLUDES=(
     "dist"
     "pantheon-content-publisher.php"
     "vendor"
+    "composer.json"
 )
 
 # Determine repository name from the current directory.


### PR DESCRIPTION
Small PR that adds `composer.json` to our release build as requested by the WP.org Review Team