### PR TITLE
[BUGS-10458] Adds db calls cached variable

### DIFF
--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -173,12 +173,12 @@ class PccSyncManager
 	private function syncPostMetaAndTags($postId, Article $article): void
 	{
 		//static variable persists between calls withing the same request
-		static $yoastActive; // implicitly null 
+		static $yoastActive; // implicitly null
 
 		// Cache Yoast active status for this request to avoid repeated DB checks
 		if (!isset($yoastActive)) {
-		    $activePlugins = apply_filters('active_plugins', get_option('active_plugins'));
-		    $yoastActive = in_array('wordpress-seo/wp-seo.php', $activePlugins, true);
+			$activePlugins = apply_filters('active_plugins', get_option('active_plugins'));
+			$yoastActive = in_array('wordpress-seo/wp-seo.php', $activePlugins, true);
 		}
 
 		if (isset($article->tags) && is_array($article->tags)) {


### PR DESCRIPTION
Use static variable caching to ensure the query executes once per request instead of once per article.

Analysis, reporting and solution in https://getpantheon.atlassian.net/browse/BUGS-10458 