### PR TITLE
remove dry run flag from deploy action

### DIFF
--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -12,8 +12,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@2.3.0
-      with:
-        dry-run: true
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
Removes `dry-run` flag from deploy workflow so plugin deploy will push to .org.