### PR TITLE
[SITE-5421] Smart components and media embed (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pantheon Content Publisher for WordPress
 
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [a11rew](https://profiles.wordpress.org/a11rew), [anaispantheor](https://profiles.wordpress.org/anaispantheor/), [roshnykunjappan](https://profiles.wordpress.org/roshnykunjappan/), [mklasen](https://profiles.wordpress.org/mklasen/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [swb1192](https://profiles.wordpress.org/swb1192)
-**Tags:** pantheon, content, google docs, acf
+**Tags:** pantheon, content, google docs, acf, embeds
 **Requires at least:** 5.7  
 **Tested up to:** 6.9  
 **Stable tag:** 1.4.0-dev  
@@ -42,6 +42,7 @@
 - [Table of contents](#table-of-contents)
 - [Quick start](#quick-start)
 - [Custom post types](#custom-post-types)
+- [Smart Components](#smart-components)
 - [ACF Integration](#acf-integration)
 - [Development](#development)
 - [Repository Actions](#repository-actions)
@@ -104,6 +105,7 @@ The plugin falls back to the default `post` type in the following cases:
 
 Changing the post type setting on a collection only affects future publishes and does not modify previously published content.
 
+<<<<<<< HEAD
 ## ACF Integration
 
 The plugin can sync Content Publisher metadata fields to [Advanced Custom Fields (ACF)](https://www.advancedcustomfields.com/). When a document is published, mapped ACF fields are automatically populated with the corresponding metadata values.
@@ -126,6 +128,55 @@ Mappings are scoped per post type. When a document is published, only the mappin
 ### Error visibility
 
 Sync errors (missing metadata fields, unresolved users, ACF inactive) are displayed in the Integration tab under a "Errors from last sync" banner. Errors auto-clear after one hour.
+
+## Smart Components
+
+Smart Components let authors embed rich media directly from Google Docs. When a document is published, these components are rendered as native WordPress embeds.
+
+### Adding a component in Google Docs
+
+1. Open your document in Google Docs with the Content Publisher add-on enabled.
+2. Type the '@' symbol in the document, a pop-up will show in which you can search for integrations, search for "Pantheon" and choose the "Pantheon Component". You will then see a pop-up.
+3. Select **Media Embed** from the list of available components.
+4. Enter the media URL (e.g. a YouTube or Vimeo link).
+5. Optionally set custom **width** and **height** values (in px or %).
+6. A live preview of the embed appears in the sidebar.
+7. When the document is published, the component renders as a native WordPress embed in the post content.
+
+### Supported providers
+
+Media Embed supports any provider recognized by WordPress oEmbed, including:
+
+- YouTube
+- Vimeo
+- Spotify
+- DailyMotion
+- Flickr
+- Twitter / X
+- Instagram
+
+If a URL is not recognized by any WordPress oEmbed provider, the plugin falls back to rendering a plain `<iframe>`.
+
+Default dimensions are **100% width** and **400px height**. Authors can override these per component.
+
+### Registering custom components
+
+Developers can register custom smart components using the `cpub_register_smart_components` action hook. Each component must implement the `SmartComponentInterface` (`Pantheon\ContentPublisher\Interfaces\SmartComponentInterface`), which requires four methods:
+
+- `type(): string` — A unique identifier (e.g. `'MY_COMPONENT'`).
+- `schema(): array` — The field schema exposed to the Google Docs add-on.
+- `render(array $attrs): string` — Returns the HTML output for the component.
+- `allowedHtmlTags(): array` — HTML tags and attributes required by the component for `wp_kses`.
+
+```php
+add_action('cpub_register_smart_components', function ($registry) {
+    $registry->register(new My_Custom_Component());
+});
+```
+
+### Limitations
+
+- Components must be placed in their own paragraph in Google Docs. Inline placement within other text can cause issues.
 
 ## Development
 

--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,6 @@
 === Pantheon Content Publisher ===
 Contributors: getpantheon, a11rew, anaispantheor, roshnykunjappan, mklasen, jazzs3quence, swb1192
-Tags: pantheon, acf, google docs
+Tags: pantheon, acf, google docs, embeds
 Requires at least: 5.7
 Tested up to: 6.9
 Stable tag: 1.4.0-dev
@@ -24,7 +24,7 @@ Enable direct publishing from Google Docs to WordPress, simplifying content mana
 Publish content to any public post type registered on your WordPress site, including custom post types. Authors can also specify the target post type per document via metadata.
 
 = Smart Components =
-Embed rich media (YouTube, Vimeo, etc.) directly from Google Docs using the Content Publisher add-on. Components are rendered as native WordPress embeds on publish.
+Embed rich media directly from Google Docs using the Content Publisher add-on. In the add-on sidebar, click Add Component, select Media Embed and enter a URL. Supported providers include YouTube, Vimeo, Spotify, DailyMotion, Flickr, Twitter/X, Instagram and any other provider recognized by WordPress oEmbed. Unrecognized URLs fall back to an iframe embed. Authors can set custom width and height per component — defaults are 100% width and 400px height. Components are rendered as native WordPress embeds on publish with no admin configuration required. Developers can register custom components via the `cpub_register_smart_components` hook.
 
 = ACF Integration =
 Sync Content Publisher metadata fields to Advanced Custom Fields (ACF). Navigate to Settings > Pantheon Content Publisher > Integration tab to define field mappings per post type. Each tab shows ACF fields from the field groups assigned to that post type — enter the exact Content Publisher metadata field name (case-sensitive) to create a mapping. Mapped values are automatically applied on every publish. Sync errors are displayed in the Integration tab and auto-clear after one hour. Requires the ACF plugin (free or Pro) to be installed and active. Works with custom post types.
@@ -41,6 +41,7 @@ Once connected:
 
 * **Connection tab** — Configure collections and choose the target post type (including custom post types).
 * **Integration tab** — Map Content Publisher metadata fields to ACF fields per post type (requires the ACF plugin).
+* **Smart Components** — Work automatically with no extra configuration. Authors add media embeds from the Google Docs add-on.
 
 == Integration with Third-Party Services ==
 
@@ -71,6 +72,7 @@ The connection will be established automatically.
 = What happens if I disconnect Pantheon Content Publisher from my Google Drive? =
 All posts/pages created with Pantheon Content Publisher will remain on your WordPress site. However, you will no longer be able to edit them from Google Docs.
 
+<<<<<<< HEAD
 = How do I map metadata to ACF fields? =
 Go to Settings > Pantheon Content Publisher > Integration tab. Select a post type tab, then enter the exact Content Publisher metadata field name next to each ACF field you want to map. Values sync automatically on every publish. The ACF plugin (free or Pro) must be installed and active.
 
@@ -79,6 +81,10 @@ Yes. The ACF plugin must be installed and active. If ACF is not detected, the In
 
 = Can I publish to custom post types? =
 Yes. When creating or editing a collection, select the target post type from the dropdown. You can also select "Chosen by the author" to let document authors control the post type via the `wp-post-type` metadata field.
+=======
+= How do I embed media from Google Docs? =
+Enter the '@' symbol in the document, a pop-up will show in which you can search for integrations, search for "Pantheon" and choose the "Pantheon Component". You will then see a pop-up in which you can select the Media Embed.
+>>>>>>> e19bbe2 (Add smart components documentation from PR #203)
 
 == Changelog ==
 

--- a/README.txt
+++ b/README.txt
@@ -23,6 +23,9 @@ Enable direct publishing from Google Docs to WordPress, simplifying content mana
 = Custom Post Type Support =
 Publish content to any public post type registered on your WordPress site, including custom post types. Authors can also specify the target post type per document via metadata.
 
+= Smart Components =
+Embed rich media (YouTube, Vimeo, etc.) directly from Google Docs using the Content Publisher add-on. Components are rendered as native WordPress embeds on publish.
+
 = ACF Integration =
 Sync Content Publisher metadata fields to Advanced Custom Fields (ACF). Navigate to Settings > Pantheon Content Publisher > Integration tab to define field mappings per post type. Each tab shows ACF fields from the field groups assigned to that post type — enter the exact Content Publisher metadata field name (case-sensitive) to create a mapping. Mapped values are automatically applied on every publish. Sync errors are displayed in the Integration tab and auto-clear after one hour. Requires the ACF plugin (free or Pro) to be installed and active. Works with custom post types.
 
@@ -83,6 +86,7 @@ Yes. When creating or editing a collection, select the target post type from the
 
 = 1.3.5 (5 March 2026) =
 * Feature: ACF integration — sync Content Publisher metadata fields to Advanced Custom Fields with per-post-type mappings [#201](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/pull/201)
+* Feature: Smart Components foundation with Media Embed support for embedding videos and media via Google Docs add-on [#200](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/pull/200)
 * Feature: Add support for publishing to custom post types with author-choice mode via `wp-post-type` metadata field [#193](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/pull/193)
 * Fix: Async thumbnail generation for featured images to prevent PHP-FPM timeouts on Pantheon [#196](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/pull/196)
 * Fix: Webhook secret validation is now optional rather than required, preventing 500 errors for unconfigured secrets [#195](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/pull/195)

--- a/app/ComponentEndpoints.php
+++ b/app/ComponentEndpoints.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Pantheon\ContentPublisher;
+
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols -- WordPress direct access guard, consistent with rest of codebase.
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * REST API endpoints for smart component schema and preview.
+ *
+ * The Google Docs add-on fetches the component schema to know what
+ * smart components are available, and uses the preview endpoint to
+ * render component output inside the editor sidebar.
+ */
+class ComponentEndpoints
+{
+	private const SCHEMA_PATH = 'api/pantheoncloud/component_schema';
+	private const COMPONENT_PATH = 'api/pantheoncloud/component';
+
+	/**
+	 * @var SmartComponents
+	 */
+	private SmartComponents $smartComponents;
+
+	public function __construct(SmartComponents $smartComponents)
+	{
+		$this->smartComponents = $smartComponents;
+
+		add_action('rest_api_init', [$this, 'registerRoutes']);
+		add_action('template_redirect', [$this, 'handleRedirects']);
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function registerRoutes(): void
+	{
+		register_rest_route(CPUB_API_NAMESPACE, '/' . self::SCHEMA_PATH, [
+			'methods' => 'GET',
+			'callback' => [$this, 'getComponentSchema'],
+			'permission_callback' => '__return_true',
+		]);
+
+		register_rest_route(
+			CPUB_API_NAMESPACE,
+			'/' . self::COMPONENT_PATH . '/(?P<component_id>[a-zA-Z0-9_-]+)',
+			[
+				'methods' => 'GET',
+				'callback' => [$this, 'handleComponentPreview'],
+				'permission_callback' => '__return_true',
+				'args' => [
+					'component_id' => [
+						'required' => true,
+						'type' => 'string',
+					],
+					'attrs' => [
+						'required' => false,
+						'type' => 'string',
+						'description' => 'Base64-encoded JSON attributes',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Redirect pretty URLs to REST API equivalents.
+	 *
+	 * @SuppressWarnings(PHPMD.ShortVariable) -- $wp is the WordPress global.
+	 * @SuppressWarnings(PHPMD.Superglobals) -- $_SERVER access required by WordPress.
+	 * @SuppressWarnings(PHPMD.ExitExpression) -- exit after wp_safe_redirect is required by WordPress.
+	 */
+	public function handleRedirects(): void
+	{
+		global $wp;
+
+		if (self::SCHEMA_PATH === $wp->request) {
+			wp_safe_redirect(rest_url(CPUB_API_NAMESPACE . '/' . self::SCHEMA_PATH));
+			exit;
+		}
+
+		$pattern = '#^' . self::COMPONENT_PATH . '/([a-zA-Z0-9_-]+)#';
+		if (!preg_match($pattern, $wp->request, $matches)) {
+			return;
+		}
+
+		$queryString = isset($_SERVER['QUERY_STRING'])
+			? sanitize_text_field(wp_unslash($_SERVER['QUERY_STRING']))
+			: '';
+		$url = rest_url(
+			CPUB_API_NAMESPACE . '/' . self::COMPONENT_PATH . '/' . $matches[1]
+		);
+		if ($queryString) {
+			$url .= '?' . $queryString;
+		}
+		wp_safe_redirect($url);
+		exit;
+	}
+
+	/**
+	 * Return the smart component schema.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function getComponentSchema(): WP_REST_Response
+	{
+		$response = new WP_REST_Response(
+			$this->smartComponents->getSchema(),
+			200
+		);
+		$response->header('Access-Control-Allow-Origin', '*');
+		$response->header('Access-Control-Allow-Methods', 'GET, OPTIONS');
+		$response->header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+		return $response;
+	}
+
+	/**
+	 * Handle a component preview request.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @SuppressWarnings(PHPMD.ExitExpression) -- Raw HTML output bypasses REST serialization.
+	 */
+	public function handleComponentPreview(WP_REST_Request $request): void
+	{
+		$componentId = strtoupper(sanitize_text_field($request->get_param('component_id')));
+		$attrsEncoded = $request->get_param('attrs');
+
+		$attrs = [];
+		if ($attrsEncoded) {
+			$decoded = base64_decode($attrsEncoded, true);
+			if ($decoded !== false) {
+				$attrs = json_decode($decoded, true) ?: [];
+			}
+		}
+
+		$html = $this->smartComponents->renderComponent($componentId, $attrs);
+
+		header('Access-Control-Allow-Origin: *');
+		header('Content-Type: text/html; charset=UTF-8');
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped by component render()
+		echo '<!DOCTYPE html><html><head>'
+			. '<meta charset="utf-8">'
+			. '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
+			. '<style>body { margin: 0; padding: 16px; }</style>'
+			. '</head><body>' . $html . '</body></html>';
+		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
+		exit; // Required: bypass REST API JSON serialization for raw HTML preview.
+	}
+}

--- a/app/ComponentEndpoints.php
+++ b/app/ComponentEndpoints.php
@@ -116,6 +116,7 @@ class ComponentEndpoints
 		$response->header('Access-Control-Allow-Origin', '*');
 		$response->header('Access-Control-Allow-Methods', 'GET, OPTIONS');
 		$response->header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+		$response->header('Cache-Control', 'no-store');
 
 		return $response;
 	}
@@ -143,6 +144,7 @@ class ComponentEndpoints
 		$html = $this->smartComponents->renderComponent($componentId, $attrs);
 
 		header('Access-Control-Allow-Origin: *');
+		header('Cache-Control: no-store');
 		header('Content-Type: text/html; charset=UTF-8');
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped by component render()
 		echo '<!DOCTYPE html><html><head>'

--- a/app/Components/MediaEmbed.php
+++ b/app/Components/MediaEmbed.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Pantheon\ContentPublisher\Components;
+
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols -- WordPress direct access guard, consistent with rest of codebase.
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+use Pantheon\ContentPublisher\Interfaces\SmartComponentInterface;
+
+/**
+ * Media Embed smart component.
+ *
+ * Renders embedded media (YouTube, Vimeo, etc.) using WordPress oEmbed
+ * with an iframe fallback for unsupported providers.
+ */
+class MediaEmbed implements SmartComponentInterface
+{
+	private const DEFAULT_WIDTH = '100%';
+	private const DEFAULT_HEIGHT = '400px';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function type(): string
+	{
+		return 'MEDIA_EMBED';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function schema(): array
+	{
+		return [
+			'title' => 'Media Embed',
+			'iconUrl' => null,
+			'fields' => [
+				'url' => [
+					'displayName' => 'URL',
+					'type' => 'string',
+					'required' => true,
+				],
+				'width' => [
+					'displayName' => 'Width',
+					'type' => 'string',
+					'required' => false,
+				],
+				'height' => [
+					'displayName' => 'Height',
+					'type' => 'string',
+					'required' => false,
+				],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function allowedHtmlTags(): array
+	{
+		return [
+			'iframe' => [
+				'src' => true,
+				'width' => true,
+				'height' => true,
+				'style' => true,
+				'allowfullscreen' => true,
+				'loading' => true,
+				'frameborder' => true,
+				'allow' => true,
+				'title' => true,
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render(array $attrs): string
+	{
+		$url = $attrs['url'] ?? '';
+		if (empty($url) || !filter_var($url, FILTER_VALIDATE_URL)) {
+			return '';
+		}
+
+		$width = !empty($attrs['width']) ? $attrs['width'] : self::DEFAULT_WIDTH;
+		$height = !empty($attrs['height']) ? $attrs['height'] : self::DEFAULT_HEIGHT;
+
+		return $this->renderOembed($url, $width, $height)
+			?? $this->renderIframe($url, $width, $height);
+	}
+
+	/**
+	 * Render using WordPress oEmbed for supported providers (YouTube, Vimeo, etc.).
+	 *
+	 * Overrides the iframe dimensions in the oEmbed response to match the
+	 * author's requested values.
+	 *
+	 * @return string|null Rendered HTML, or null if the provider is not supported.
+	 */
+	private function renderOembed(string $url, string $width, string $height): ?string
+	{
+		$oembedArgs = [];
+		$numericWidth = (int) $width;
+		if ($numericWidth > 0 && $width !== '100%') {
+			$oembedArgs['width'] = $numericWidth;
+		}
+		$numericHeight = (int) $height;
+		if ($numericHeight > 0) {
+			$oembedArgs['height'] = $numericHeight;
+		}
+
+		$html = wp_oembed_get($url, $oembedArgs);
+		if (!$html) {
+			return null;
+		}
+
+		// Override iframe dimensions to match the author's values.
+		$doc = new \DOMDocument();
+		@$doc->loadHTML('<body>' . $html . '</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+
+		$iframes = $doc->getElementsByTagName('iframe');
+		if ($iframes->length > 0) {
+			$iframe = $iframes->item(0);
+			$iframe->setAttribute('width', '100%');
+			$iframe->setAttribute('height', $height);
+		}
+
+		$body = $doc->getElementsByTagName('body')->item(0);
+		$html = '';
+		if ($body) {
+			foreach ($body->childNodes as $child) {
+				$html .= $doc->saveHTML($child);
+			}
+		}
+
+		return sprintf(
+			'<div class="cpub-media-embed" style="width:%s;margin:1.5em 0;">%s</div>',
+			esc_attr($width),
+			$html
+		);
+	}
+
+	/**
+	 * Render a plain iframe for providers not supported by WordPress oEmbed.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	private function renderIframe(string $url, string $width, string $height): string
+	{
+		return sprintf(
+			'<div class="cpub-media-embed" style="width:%s;margin:1.5em 0;">'
+			. '<iframe src="%s" style="width:100%%;height:%s;border:0;" '
+			. 'allowfullscreen loading="lazy"></iframe></div>',
+			esc_attr($width),
+			esc_url($url),
+			esc_attr($height)
+		);
+	}
+}

--- a/app/Interfaces/SmartComponentInterface.php
+++ b/app/Interfaces/SmartComponentInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Pantheon\ContentPublisher\Interfaces;
+
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols -- WordPress direct access guard, consistent with rest of codebase.
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Interface for smart components.
+ *
+ * Each smart component (e.g. Media Embed) implements this interface
+ * and is registered with the SmartComponents registry.
+ */
+interface SmartComponentInterface
+{
+	/**
+	 * Return the component type identifier (e.g. 'MEDIA_EMBED').
+	 *
+	 * @return string
+	 */
+	public function type(): string;
+
+	/**
+	 * Return the component schema for the Google Docs add-on.
+	 *
+	 * @return array
+	 */
+	public function schema(): array;
+
+	/**
+	 * Render the component to HTML.
+	 *
+	 * @param array $attrs Component attributes.
+	 * @return string
+	 */
+	public function render(array $attrs): string;
+
+	/**
+	 * Return HTML tags and attributes required by this component
+	 * for wp_kses_allowed_html.
+	 *
+	 * Format: ['tag' => ['attribute' => true, ...], ...]
+	 *
+	 * @return array
+	 */
+	public function allowedHtmlTags(): array;
+}

--- a/app/PccSyncManager.php
+++ b/app/PccSyncManager.php
@@ -24,6 +24,23 @@ class PccSyncManager
 	private string $siteId;
 	private string $apiKey;
 
+	/**
+	 * Post ID being saved in the current sync operation.
+	 * Used by the kses filter in Settings::allowStyleTags() to resolve the post
+	 * in REST/webhook context where get_the_ID() returns 0.
+	 *
+	 * @var int
+	 */
+	private static int $savingPostId = 0;
+
+	/**
+	 * Return the post ID currently being saved, or 0 if none.
+	 */
+	public function getSavingPostId(): int
+	{
+		return self::$savingPostId;
+	}
+
 	public function __construct()
 	{
 		$this->siteId = get_option(CPUB_SITE_ID_OPTION_KEY);
@@ -62,6 +79,30 @@ class PccSyncManager
 			ContentType::TREE_PANTHEON_V2,
 			$versionId
 		);
+
+		// Smart components (e.g. Media Embed) require a dual-fetch approach.
+		// The TREE_PANTHEON_V2 content contains only bare <component></component>
+		// placeholders — it does not include the component type or attributes.
+		// Those live in the raw content (null content type) as <pcc-component>
+		// tags with base64-encoded attrs. We fetch the raw content only when
+		// placeholders are detected, extract the component metadata, and render
+		// each component into the processed HTML.
+		$smartComponents = new SmartComponents();
+		if ($article && $smartComponents->contentHasComponents($article->content)) {
+			$rawArticle = $articlesApi->getArticleById(
+				$documentId,
+				['id', 'content'],
+				$publishingLevel,
+				null,
+				$versionId
+			);
+			if ($rawArticle && $rawArticle->content) {
+				$article->content = $smartComponents->processContent(
+					$article->content,
+					$rawArticle->content
+				);
+			}
+		}
 
 		return $article ? $this->storeArticle($article, $isDraft) : 0;
 	}
@@ -156,15 +197,34 @@ class PccSyncManager
 		if (!$postId) {
 			$insertData = $data;
 			$insertData['post_author'] = $this->getDefaultAuthorId($article);
-			$postId = wp_insert_post($insertData);
+			$postId = $this->savePost($insertData);
 			update_post_meta($postId, CPUB_CONTENT_META_KEY, $article->id);
 			$this->syncPostMetaAndTags($postId, $article);
 			return $postId;
 		}
 
 		$data['ID'] = $postId;
-		wp_update_post($data);
+		$this->savePost($data);
 		$this->syncPostMetaAndTags($postId, $article);
+		return $postId;
+	}
+
+	/**
+	 * Insert or update a WordPress post, exposing the post ID via a static
+	 * property so that the kses filter in Settings::allowStyleTags() can
+	 * resolve which post is being saved in REST/webhook context (where
+	 * get_the_ID() returns 0).
+	 *
+	 * @param array $data wp_insert_post / wp_update_post args.
+	 * @return int The saved post ID.
+	 */
+	private function savePost(array $data): int
+	{
+		self::$savingPostId = $data['ID'] ?? 0;
+		$postId = isset($data['ID'])
+			? (int) wp_update_post($data)
+			: (int) wp_insert_post($data);
+		self::$savingPostId = 0;
 		return $postId;
 	}
 

--- a/app/Plugin.php
+++ b/app/Plugin.php
@@ -40,8 +40,10 @@ class Plugin
 	 */
 	private function init(): void
 	{
-		new Settings();
-		new RestController();
+		$smartComponents = new SmartComponents();
+		new Settings($smartComponents);
+		new RestController($smartComponents);
+		new ComponentEndpoints($smartComponents);
 		new Admin();
 
 		// Register cron action for async thumbnail generation

--- a/app/RestController.php
+++ b/app/RestController.php
@@ -28,11 +28,13 @@ use const CPUB_ACCESS_TOKEN_OPTION_KEY;
  */
 class RestController
 {
+	private SmartComponents $smartComponents;
 	/**
 	 * Class constructor, hooking into the REST API initialization.
 	 */
-	public function __construct()
+	public function __construct(SmartComponents $smartComponents)
 	{
+		$this->smartComponents = $smartComponents;
 		add_action('rest_api_init', [$this, 'registerRoutes']);
 	}
 
@@ -142,9 +144,9 @@ class RestController
 		$isPCCConfigured = $pccManager->isPCCConfigured();
 
 		$options = new StatusOptions(
-			smartComponents: false,
-			smartComponentsCount: 0,
-			smartComponentPreview: false,
+			smartComponents: $this->smartComponents->count() > 0,
+			smartComponentsCount: $this->smartComponents->count(),
+			smartComponentPreview: $this->smartComponents->count() > 0,
 			metadataGroups: false,
 			metadataGroupIdentifiers: null,
 			resolvePathConfigured: true,

--- a/app/RestController.php
+++ b/app/RestController.php
@@ -156,7 +156,9 @@ class RestController
 
 		$payload = $status->toArray();
 
-		return new WP_REST_Response($payload);
+		$response = new WP_REST_Response($payload);
+		$response->header('Cache-Control', 'no-store');
+		return $response;
 	}
 
 	/**

--- a/app/SmartComponents.php
+++ b/app/SmartComponents.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Pantheon\ContentPublisher;
+
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols -- WordPress direct access guard, consistent with rest of codebase.
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+use Pantheon\ContentPublisher\Components\MediaEmbed;
+use Pantheon\ContentPublisher\Interfaces\SmartComponentInterface;
+
+/**
+ * Smart component registry and processing pipeline.
+ *
+ * Manages registered SmartComponentInterface instances and provides
+ * the generic content pipeline (detection, extraction, replacement).
+ *
+ * Third parties can register components via:
+ *   add_action('cpub_register_smart_components', function($registry) {
+ *       $registry->register(new My_Custom_Component());
+ *   });
+ */
+class SmartComponents
+{
+	/**
+	 * @var SmartComponentInterface[] Registered components keyed by type.
+	 */
+	private array $components = [];
+
+	public function __construct()
+	{
+		$this->register(new MediaEmbed());
+
+		/**
+		 * Fires after built-in smart components are registered.
+		 *
+		 * Third-party plugins can use this hook to register their own
+		 * smart components:
+		 *
+		 *   add_action('cpub_register_smart_components', function($registry) {
+		 *       $registry->register(new My_Custom_Component());
+		 *   });
+		 *
+		 * @param SmartComponents $registry The smart components registry.
+		 */
+		do_action('cpub_register_smart_components', $this);
+	}
+
+	/**
+	 * Register a smart component.
+	 *
+	 * @param SmartComponentInterface $component
+	 */
+	public function register(SmartComponentInterface $component): void
+	{
+		$this->components[strtoupper($component->type())] = $component;
+	}
+
+	/**
+	 * Get the number of registered components.
+	 *
+	 * @return int
+	 */
+	public function count(): int
+	{
+		return count($this->components);
+	}
+
+	/**
+	 * Build the schema array for all registered components.
+	 *
+	 * @return array
+	 */
+	public function getSchema(): array
+	{
+		$schema = [];
+		foreach ($this->components as $type => $component) {
+			$schema[$type] = $component->schema();
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Render a component by type.
+	 *
+	 * @param string $type Component type identifier.
+	 * @param array $attrs Component attributes.
+	 * @return string Rendered HTML or empty string if type is not registered.
+	 */
+	public function renderComponent(string $type, array $attrs): string
+	{
+		$type = strtoupper($type);
+		if (!isset($this->components[$type])) {
+			return '';
+		}
+
+		return $this->components[$type]->render($attrs);
+	}
+
+	/**
+	 * Collect allowed HTML tags from all registered components.
+	 *
+	 * Merges each component's allowedHtmlTags() into a single array
+	 * suitable for wp_kses_allowed_html.
+	 *
+	 * @return array
+	 */
+	public function getAllowedHtmlTags(): array
+	{
+		$tags = [];
+		foreach ($this->components as $component) {
+			foreach ($component->allowedHtmlTags() as $tag => $attrs) {
+				if (!isset($tags[$tag])) {
+					$tags[$tag] = $attrs;
+					continue;
+				}
+				$tags[$tag] = array_merge($tags[$tag], $attrs);
+			}
+		}
+
+		return $tags;
+	}
+
+	// ── Content pipeline ────────────────────────────────────────────
+
+	/**
+	 * Check if processed content contains component placeholders.
+	 *
+	 * @param string $content TREE_PANTHEON_V2 HTML content.
+	 * @return bool
+	 */
+	public function contentHasComponents(string $content): bool
+	{
+		return (bool) preg_match('/<component[\s>]/i', $content);
+	}
+
+	/**
+	 * Extract smart component data from raw PCC content.
+	 *
+	 * Raw content contains tags like:
+	 * <pcc-component id="..." type="MEDIA_EMBED" attrs="base64json"></pcc-component>
+	 *
+	 * @param string $rawContent Raw HTML from PCC (null content type).
+	 * @return array Array of component data with 'type' and 'attrs' keys.
+	 */
+	public function extractFromRawContent(string $rawContent): array
+	{
+		$components = [];
+		$pattern = '/<pcc-component\s+[^>]*?type="([^"]+)"[^>]*?attrs="([^"]+)"[^>]*><\/pcc-component>/i';
+
+		if (preg_match_all($pattern, $rawContent, $matches, PREG_SET_ORDER)) {
+			foreach ($matches as $match) {
+				$decodedAttrs = base64_decode($match[2], true);
+				$attrs = $decodedAttrs !== false ? json_decode($decodedAttrs, true) : null;
+
+				$components[] = [
+					'type' => $match[1],
+					'attrs' => is_array($attrs) ? $attrs : [],
+				];
+			}
+		}
+
+		return $components;
+	}
+
+	/**
+	 * Replace <component></component> placeholders in processed content
+	 * with rendered embed HTML.
+	 *
+	 * @param string $processedContent TREE_PANTHEON_V2 HTML.
+	 * @param array $components Extracted component data from raw content.
+	 * @return string Content with embeds rendered.
+	 */
+	public function replaceComponentPlaceholders(
+		string $processedContent,
+		array $components
+	): string {
+		if (empty($components)) {
+			return $processedContent;
+		}
+
+		$index = 0;
+
+		return preg_replace_callback(
+			'/<component[^>]*><\/component>/i',
+			function ($matches) use (&$index, $components) {
+				if (!isset($components[$index])) {
+					$index++;
+					return $matches[0];
+				}
+
+				$component = $components[$index++];
+				$type = strtoupper($component['type']);
+
+				if (isset($this->components[$type])) {
+					return $this->components[$type]->render($component['attrs']);
+				}
+
+				return '<!-- unsupported smart component: ' . esc_html($component['type']) . ' -->';
+			},
+			$processedContent
+		);
+	}
+
+	/**
+	 * Full pipeline: process smart components in content.
+	 *
+	 * Extracts component metadata from raw content and replaces
+	 * <component> placeholders in processed content with rendered embeds.
+	 *
+	 * @param string $processedContent TREE_PANTHEON_V2 HTML.
+	 * @param string|null $rawContent Raw HTML (fetched with null content type).
+	 * @return string Final content with embeds rendered.
+	 */
+	public function processContent(
+		string $processedContent,
+		?string $rawContent
+	): string {
+		if (!$rawContent) {
+			return $processedContent;
+		}
+
+		$components = $this->extractFromRawContent($rawContent);
+		if (empty($components)) {
+			return $processedContent;
+		}
+
+		return $this->replaceComponentPlaceholders($processedContent, $components);
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,11 @@
       "Pantheon\\ContentPublisher\\": "app/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Pantheon\\ContentPublisher\\Tests\\": "tests/phpunit/"
+    }
+  },
   "require": {
     "php": ">=8.1",
     "pantheon-systems/pcc-php-sdk": "1.1.1"

--- a/tests/phpunit/MediaEmbedTest.php
+++ b/tests/phpunit/MediaEmbedTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * PHPUnit tests for the MediaEmbed smart component.
+ *
+ * Covers the render() method: URL validation, default and custom
+ * dimensions, oEmbed and iframe fallback.
+ */
+
+namespace Pantheon\ContentPublisher\Tests;
+
+use Pantheon\ContentPublisher\Components\MediaEmbed;
+use WP_UnitTestCase;
+
+class MediaEmbedTest extends WP_UnitTestCase
+{
+	private MediaEmbed $mediaEmbed;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->mediaEmbed = new MediaEmbed();
+	}
+
+	// ── Interface compliance ────────────────────────────────────────
+
+	public function testTypeReturnsMediaEmbed(): void
+	{
+		$this->assertSame('MEDIA_EMBED', $this->mediaEmbed->type());
+	}
+
+	public function testSchemaHasRequiredFields(): void
+	{
+		$schema = $this->mediaEmbed->schema();
+
+		$this->assertArrayHasKey('title', $schema);
+		$this->assertArrayHasKey('fields', $schema);
+		$this->assertArrayHasKey('url', $schema['fields']);
+		$this->assertArrayHasKey('width', $schema['fields']);
+		$this->assertArrayHasKey('height', $schema['fields']);
+		$this->assertTrue($schema['fields']['url']['required']);
+		$this->assertFalse($schema['fields']['width']['required']);
+	}
+
+	// ── render() ────────────────────────────────────────────────────
+
+	public function testRenderReturnsEmptyForMissingUrl(): void
+	{
+		$this->assertSame('', $this->mediaEmbed->render([]));
+	}
+
+	public function testRenderReturnsEmptyForEmptyUrl(): void
+	{
+		$this->assertSame('', $this->mediaEmbed->render(['url' => '']));
+	}
+
+	public function testRenderReturnsEmptyForInvalidUrl(): void
+	{
+		$this->assertSame('', $this->mediaEmbed->render(['url' => 'not-a-url']));
+	}
+
+	public function testRenderProducesEmbedWithDefaultDimensions(): void
+	{
+		$html = $this->mediaEmbed->render(['url' => 'https://example.com/video']);
+
+		$this->assertStringContainsString('class="cpub-media-embed"', $html);
+		$this->assertStringContainsString('width:100%', $html);
+		$this->assertStringContainsString('height:400px', $html);
+		$this->assertStringContainsString('example.com/video', $html);
+	}
+
+	public function testRenderRespectsCustomDimensions(): void
+	{
+		$html = $this->mediaEmbed->render([
+			'url' => 'https://example.com/video',
+			'width' => '600px',
+			'height' => '300px',
+		]);
+
+		$this->assertStringContainsString('width:600px', $html);
+		$this->assertStringContainsString('height:300px', $html);
+	}
+
+	public function testRenderFallsBackToIframe(): void
+	{
+		// Use an unusual URL that wp_oembed_get() won't support.
+		$html = $this->mediaEmbed->render(['url' => 'https://example.com/custom-video']);
+
+		$this->assertStringContainsString('<iframe', $html);
+		$this->assertStringContainsString('src="https://example.com/custom-video"', $html);
+		$this->assertStringContainsString('allowfullscreen', $html);
+		$this->assertStringContainsString('loading="lazy"', $html);
+	}
+}

--- a/tests/phpunit/RestControllerTest.php
+++ b/tests/phpunit/RestControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Tests that pantheoncloud REST endpoints send Cache-Control: no-store.
+ */
+
+namespace Pantheon\ContentPublisher\Tests;
+
+use Pantheon\ContentPublisher\ComponentEndpoints;
+use Pantheon\ContentPublisher\RestController;
+use Pantheon\ContentPublisher\SmartComponents;
+use WP_UnitTestCase;
+
+class RestControllerTest extends WP_UnitTestCase
+{
+	public function testStatusCheckHasNoCacheHeader(): void
+	{
+		$controller = new RestController(new SmartComponents());
+		$response = $controller->pantheonCloudStatusCheck();
+		$headers = $response->get_headers();
+
+		$this->assertArrayHasKey('Cache-Control', $headers);
+		$this->assertStringContainsString('no-store', $headers['Cache-Control']);
+	}
+
+	public function testGetComponentSchemaHasNoCacheHeader(): void
+	{
+		$endpoints = new ComponentEndpoints(new SmartComponents());
+		$response = $endpoints->getComponentSchema();
+		$headers = $response->get_headers();
+
+		$this->assertArrayHasKey('Cache-Control', $headers);
+		$this->assertStringContainsString('no-store', $headers['Cache-Control']);
+	}
+}

--- a/tests/phpunit/SmartComponentsDetectionTest.php
+++ b/tests/phpunit/SmartComponentsDetectionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Tests for SmartComponents content detection and raw content extraction.
+ */
+
+namespace Pantheon\ContentPublisher\Tests;
+
+use Pantheon\ContentPublisher\SmartComponents;
+use WP_UnitTestCase;
+
+class SmartComponentsDetectionTest extends WP_UnitTestCase
+{
+	private SmartComponents $registry;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->registry = new SmartComponents();
+	}
+
+	// ── contentHasComponents() ──────────────────────────────────────
+
+	/**
+	 * @dataProvider contentHasComponentsProvider
+	 */
+	public function testContentHasComponents(string $content, bool $expected): void
+	{
+		$this->assertSame($expected, $this->registry->contentHasComponents($content));
+	}
+
+	public function contentHasComponentsProvider(): array
+	{
+		return [
+			'present' => ['<p>Hello</p><component></component><p>World</p>', true],
+			'with attributes' => ['<p>Hello</p><component id="c1" data-type="test"></component>', true],
+			'absent' => ['<p>Hello World</p>', false],
+			'empty string' => ['', false],
+			'substring only' => ['<mycomponent>test</mycomponent>', false],
+		];
+	}
+
+	// ── extractFromRawContent() ─────────────────────────────────────
+
+	public function testExtractSingleComponent(): void
+	{
+		$attrs = base64_encode(json_encode(['url' => 'https://youtube.com/watch?v=abc']));
+		$raw = '<p>Text</p>'
+			. '<pcc-component id="c1" type="MEDIA_EMBED" attrs="' . $attrs . '"></pcc-component>';
+
+		$components = $this->registry->extractFromRawContent($raw);
+
+		$this->assertCount(1, $components);
+		$this->assertSame('MEDIA_EMBED', $components[0]['type']);
+		$this->assertSame('https://youtube.com/watch?v=abc', $components[0]['attrs']['url']);
+	}
+
+	public function testExtractMultipleComponents(): void
+	{
+		$attrs1 = base64_encode(json_encode(['url' => 'https://youtube.com/watch?v=1']));
+		$attrs2 = base64_encode(json_encode(['url' => 'https://vimeo.com/123']));
+		$raw = '<pcc-component id="c1" type="MEDIA_EMBED" attrs="' . $attrs1 . '"></pcc-component>'
+			. '<p>Middle</p>'
+			. '<pcc-component id="c2" type="MEDIA_EMBED" attrs="' . $attrs2 . '"></pcc-component>';
+
+		$components = $this->registry->extractFromRawContent($raw);
+
+		$this->assertCount(2, $components);
+		$this->assertSame('https://youtube.com/watch?v=1', $components[0]['attrs']['url']);
+		$this->assertSame('https://vimeo.com/123', $components[1]['attrs']['url']);
+	}
+
+	public function testExtractReturnsEmptyForNoComponents(): void
+	{
+		$this->assertEmpty($this->registry->extractFromRawContent('<p>No components here</p>'));
+	}
+
+	public function testExtractHandlesInvalidBase64(): void
+	{
+		$raw = '<pcc-component id="c1" type="MEDIA_EMBED" attrs="not-valid-base64!!!"></pcc-component>';
+		$components = $this->registry->extractFromRawContent($raw);
+
+		$this->assertCount(1, $components);
+		$this->assertSame('MEDIA_EMBED', $components[0]['type']);
+		$this->assertEmpty($components[0]['attrs']);
+	}
+
+	public function testExtractHandlesInvalidJson(): void
+	{
+		$attrs = base64_encode('not json');
+		$raw = '<pcc-component id="c1" type="MEDIA_EMBED" attrs="' . $attrs . '"></pcc-component>';
+		$components = $this->registry->extractFromRawContent($raw);
+
+		$this->assertCount(1, $components);
+		$this->assertEmpty($components[0]['attrs']);
+	}
+
+	public function testExtractPreservesWidthAndHeight(): void
+	{
+		$attrs = base64_encode(json_encode([
+			'url' => 'https://example.com/video',
+			'width' => '80%',
+			'height' => '350px',
+		]));
+		$raw = '<pcc-component id="c1" type="MEDIA_EMBED" attrs="' . $attrs . '"></pcc-component>';
+
+		$components = $this->registry->extractFromRawContent($raw);
+
+		$this->assertSame('80%', $components[0]['attrs']['width']);
+		$this->assertSame('350px', $components[0]['attrs']['height']);
+	}
+}

--- a/tests/phpunit/SmartComponentsDetectionTest.php
+++ b/tests/phpunit/SmartComponentsDetectionTest.php
@@ -44,7 +44,7 @@ class SmartComponentsDetectionTest extends WP_UnitTestCase
 
 	public function testExtractSingleComponent(): void
 	{
-		$attrs = base64_encode(json_encode(['url' => 'https://youtube.com/watch?v=abc']));
+		$attrs = base64_encode(wp_json_encode(['url' => 'https://youtube.com/watch?v=abc']));
 		$raw = '<p>Text</p>'
 			. '<pcc-component id="c1" type="MEDIA_EMBED" attrs="' . $attrs . '"></pcc-component>';
 
@@ -57,8 +57,8 @@ class SmartComponentsDetectionTest extends WP_UnitTestCase
 
 	public function testExtractMultipleComponents(): void
 	{
-		$attrs1 = base64_encode(json_encode(['url' => 'https://youtube.com/watch?v=1']));
-		$attrs2 = base64_encode(json_encode(['url' => 'https://vimeo.com/123']));
+		$attrs1 = base64_encode(wp_json_encode(['url' => 'https://youtube.com/watch?v=1']));
+		$attrs2 = base64_encode(wp_json_encode(['url' => 'https://vimeo.com/123']));
 		$raw = '<pcc-component id="c1" type="MEDIA_EMBED" attrs="' . $attrs1 . '"></pcc-component>'
 			. '<p>Middle</p>'
 			. '<pcc-component id="c2" type="MEDIA_EMBED" attrs="' . $attrs2 . '"></pcc-component>';
@@ -97,7 +97,7 @@ class SmartComponentsDetectionTest extends WP_UnitTestCase
 
 	public function testExtractPreservesWidthAndHeight(): void
 	{
-		$attrs = base64_encode(json_encode([
+		$attrs = base64_encode(wp_json_encode([
 			'url' => 'https://example.com/video',
 			'width' => '80%',
 			'height' => '350px',

--- a/tests/phpunit/SmartComponentsPipelineTest.php
+++ b/tests/phpunit/SmartComponentsPipelineTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Tests for SmartComponents placeholder replacement and full processing pipeline.
+ */
+
+namespace Pantheon\ContentPublisher\Tests;
+
+use Pantheon\ContentPublisher\SmartComponents;
+use WP_UnitTestCase;
+
+class SmartComponentsPipelineTest extends WP_UnitTestCase
+{
+	private SmartComponents $registry;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->registry = new SmartComponents();
+	}
+
+	// ── replaceComponentPlaceholders() ──────────────────────────────
+
+	public function testReplaceSubstitutesMediaEmbedPlaceholder(): void
+	{
+		$processed = '<p>Before</p><component></component><p>After</p>';
+		$components = [
+			[
+				'type' => 'MEDIA_EMBED',
+				'attrs' => ['url' => 'https://example.com/embed'],
+			],
+		];
+
+		$result = $this->registry->replaceComponentPlaceholders($processed, $components);
+
+		$this->assertStringNotContainsString('<component></component>', $result);
+		$this->assertStringContainsString('cpub-media-embed', $result);
+		$this->assertStringContainsString('example.com/embed', $result);
+		$this->assertStringContainsString('<p>Before</p>', $result);
+		$this->assertStringContainsString('<p>After</p>', $result);
+	}
+
+	public function testReplaceHandlesMultiplePlaceholdersInOrder(): void
+	{
+		$processed = '<component></component><component></component>';
+		$components = [
+			['type' => 'MEDIA_EMBED', 'attrs' => ['url' => 'https://example.com/first']],
+			['type' => 'MEDIA_EMBED', 'attrs' => ['url' => 'https://example.com/second']],
+		];
+
+		$result = $this->registry->replaceComponentPlaceholders($processed, $components);
+
+		$firstPos = strpos($result, 'example.com/first');
+		$secondPos = strpos($result, 'example.com/second');
+		$this->assertNotFalse($firstPos);
+		$this->assertNotFalse($secondPos);
+		$this->assertLessThan($secondPos, $firstPos);
+	}
+
+	public function testReplaceUnsupportedComponentLeavesComment(): void
+	{
+		$processed = '<component></component>';
+		$components = [
+			['type' => 'SOME_OTHER_TYPE', 'attrs' => ['key' => 'value']],
+		];
+
+		$result = $this->registry->replaceComponentPlaceholders($processed, $components);
+
+		$this->assertStringContainsString('unsupported smart component', $result);
+		$this->assertStringContainsString('SOME_OTHER_TYPE', $result);
+	}
+
+	public function testReplaceWithEmptyComponentsReturnsOriginal(): void
+	{
+		$processed = '<p>Content</p><component></component>';
+		$result = $this->registry->replaceComponentPlaceholders($processed, []);
+
+		$this->assertSame($processed, $result);
+	}
+
+	public function testReplaceExtraPlaceholdersPreserved(): void
+	{
+		$processed = '<component></component><component></component>';
+		$components = [
+			['type' => 'MEDIA_EMBED', 'attrs' => ['url' => 'https://example.com/only']],
+		];
+
+		$result = $this->registry->replaceComponentPlaceholders($processed, $components);
+
+		$this->assertStringContainsString('example.com/only', $result);
+		$this->assertStringContainsString('<component></component>', $result);
+	}
+
+	// ── processContent() ────────────────────────────────────────────
+
+	public function testProcessContentEndToEnd(): void
+	{
+		$attrs = base64_encode(json_encode([
+			'url' => 'https://example.com/video',
+			'width' => '80%',
+			'height' => '350px',
+		]));
+		$rawContent = '<p>Hello</p>'
+			. '<pcc-component id="c1" type="MEDIA_EMBED" attrs="' . $attrs . '"></pcc-component>';
+		$processedContent = '<p>Hello</p><component></component>';
+
+		$result = $this->registry->processContent($processedContent, $rawContent);
+
+		$this->assertStringNotContainsString('<component>', $result);
+		$this->assertStringContainsString('cpub-media-embed', $result);
+		$this->assertStringContainsString('width:80%', $result);
+	}
+
+	public function testProcessContentWithNullRawReturnsOriginal(): void
+	{
+		$processed = '<p>Normal content</p>';
+		$this->assertSame($processed, $this->registry->processContent($processed, null));
+	}
+
+	public function testProcessContentWithNoComponentsInRawReturnsOriginal(): void
+	{
+		$processed = '<p>Content</p><component></component>';
+		$raw = '<p>Content without components</p>';
+
+		$this->assertSame($processed, $this->registry->processContent($processed, $raw));
+	}
+}

--- a/tests/phpunit/SmartComponentsPipelineTest.php
+++ b/tests/phpunit/SmartComponentsPipelineTest.php
@@ -95,7 +95,7 @@ class SmartComponentsPipelineTest extends WP_UnitTestCase
 
 	public function testProcessContentEndToEnd(): void
 	{
-		$attrs = base64_encode(json_encode([
+		$attrs = base64_encode(wp_json_encode([
 			'url' => 'https://example.com/video',
 			'width' => '80%',
 			'height' => '350px',

--- a/tests/phpunit/SmartComponentsRegistryTest.php
+++ b/tests/phpunit/SmartComponentsRegistryTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Tests for SmartComponents registration, schema, and rendering.
+ */
+
+namespace Pantheon\ContentPublisher\Tests;
+
+use Pantheon\ContentPublisher\Interfaces\SmartComponentInterface;
+use Pantheon\ContentPublisher\SmartComponents;
+use WP_UnitTestCase;
+
+/**
+ * Stub component for testing third-party registration.
+ */
+class StubComponent implements SmartComponentInterface
+{
+	public function type(): string
+	{
+		return 'STUB_COMPONENT';
+	}
+
+	public function schema(): array
+	{
+		return [
+			'title' => 'Stub',
+			'iconUrl' => null,
+			'fields' => [
+				'text' => [
+					'displayName' => 'Text',
+					'type' => 'string',
+					'required' => true,
+				],
+			],
+		];
+	}
+
+	public function render(array $attrs): string
+	{
+		$text = esc_html($attrs['text'] ?? '');
+		return '<div class="stub-component">' . $text . '</div>';
+	}
+
+	public function allowedHtmlTags(): array
+	{
+		return [];
+	}
+}
+
+class SmartComponentsRegistryTest extends WP_UnitTestCase
+{
+	private SmartComponents $registry;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->registry = new SmartComponents();
+	}
+
+	public function testRegistersMediaEmbedByDefault(): void
+	{
+		$this->assertGreaterThanOrEqual(1, $this->registry->count());
+		$schema = $this->registry->getSchema();
+		$this->assertArrayHasKey('MEDIA_EMBED', $schema);
+	}
+
+	public function testRegisterAddsComponent(): void
+	{
+		$initialCount = $this->registry->count();
+		$this->registry->register(new StubComponent());
+
+		$this->assertSame($initialCount + 1, $this->registry->count());
+	}
+
+	public function testThirdPartyRegistrationViaAction(): void
+	{
+		add_action('cpub_register_smart_components', function ($registry) {
+			$registry->register(new StubComponent());
+		});
+
+		$registry = new SmartComponents();
+		$schema = $registry->getSchema();
+
+		$this->assertArrayHasKey('STUB_COMPONENT', $schema);
+		$this->assertArrayHasKey('MEDIA_EMBED', $schema);
+
+		remove_all_actions('cpub_register_smart_components');
+	}
+
+	public function testGetSchemaReturnsAllComponents(): void
+	{
+		$this->registry->register(new StubComponent());
+		$schema = $this->registry->getSchema();
+
+		$this->assertArrayHasKey('MEDIA_EMBED', $schema);
+		$this->assertArrayHasKey('STUB_COMPONENT', $schema);
+		$this->assertSame('Media Embed', $schema['MEDIA_EMBED']['title']);
+		$this->assertSame('Stub', $schema['STUB_COMPONENT']['title']);
+	}
+
+	public function testRenderComponentDelegatesToRegistered(): void
+	{
+		$this->registry->register(new StubComponent());
+		$html = $this->registry->renderComponent('STUB_COMPONENT', ['text' => 'Hello']);
+
+		$this->assertStringContainsString('stub-component', $html);
+		$this->assertStringContainsString('Hello', $html);
+	}
+
+	public function testRenderComponentReturnsEmptyForUnknownType(): void
+	{
+		$this->assertSame('', $this->registry->renderComponent('NONEXISTENT', []));
+	}
+
+	public function testRenderComponentIsCaseInsensitive(): void
+	{
+		$this->registry->register(new StubComponent());
+		$html = $this->registry->renderComponent('stub_component', ['text' => 'test']);
+
+		$this->assertStringContainsString('stub-component', $html);
+	}
+
+	public function testReplaceWithRegisteredThirdPartyComponent(): void
+	{
+		$this->registry->register(new StubComponent());
+
+		$processed = '<component></component>';
+		$components = [
+			['type' => 'STUB_COMPONENT', 'attrs' => ['text' => 'Custom']],
+		];
+
+		$result = $this->registry->replaceComponentPlaceholders($processed, $components);
+
+		$this->assertStringContainsString('stub-component', $result);
+		$this->assertStringContainsString('Custom', $result);
+	}
+}

--- a/tests/phpunit/SmartComponentsRegistryTest.php
+++ b/tests/phpunit/SmartComponentsRegistryTest.php
@@ -4,6 +4,8 @@
  * Tests for SmartComponents registration, schema, and rendering.
  */
 
+require_once __DIR__ . '/StubComponent.php';
+
 namespace Pantheon\ContentPublisher\Tests;
 
 use Pantheon\ContentPublisher\SmartComponents;

--- a/tests/phpunit/SmartComponentsRegistryTest.php
+++ b/tests/phpunit/SmartComponentsRegistryTest.php
@@ -6,46 +6,8 @@
 
 namespace Pantheon\ContentPublisher\Tests;
 
-use Pantheon\ContentPublisher\Interfaces\SmartComponentInterface;
 use Pantheon\ContentPublisher\SmartComponents;
 use WP_UnitTestCase;
-
-/**
- * Stub component for testing third-party registration.
- */
-class StubComponent implements SmartComponentInterface
-{
-	public function type(): string
-	{
-		return 'STUB_COMPONENT';
-	}
-
-	public function schema(): array
-	{
-		return [
-			'title' => 'Stub',
-			'iconUrl' => null,
-			'fields' => [
-				'text' => [
-					'displayName' => 'Text',
-					'type' => 'string',
-					'required' => true,
-				],
-			],
-		];
-	}
-
-	public function render(array $attrs): string
-	{
-		$text = esc_html($attrs['text'] ?? '');
-		return '<div class="stub-component">' . $text . '</div>';
-	}
-
-	public function allowedHtmlTags(): array
-	{
-		return [];
-	}
-}
 
 class SmartComponentsRegistryTest extends WP_UnitTestCase
 {

--- a/tests/phpunit/SmartComponentsRegistryTest.php
+++ b/tests/phpunit/SmartComponentsRegistryTest.php
@@ -4,8 +4,6 @@
  * Tests for SmartComponents registration, schema, and rendering.
  */
 
-require_once __DIR__ . '/StubComponent.php';
-
 namespace Pantheon\ContentPublisher\Tests;
 
 use Pantheon\ContentPublisher\SmartComponents;

--- a/tests/phpunit/StubComponent.php
+++ b/tests/phpunit/StubComponent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pantheon\ContentPublisher\Tests;
+
+use Pantheon\ContentPublisher\Interfaces\SmartComponentInterface;
+
+/**
+ * Stub component for testing third-party registration.
+ */
+class StubComponent implements SmartComponentInterface
+{
+	public function type(): string
+	{
+		return 'STUB_COMPONENT';
+	}
+
+	public function schema(): array
+	{
+		return [
+			'title' => 'Stub',
+			'iconUrl' => null,
+			'fields' => [
+				'text' => [
+					'displayName' => 'Text',
+					'type' => 'string',
+					'required' => true,
+				],
+			],
+		];
+	}
+
+	public function render(array $attrs): string
+	{
+		$text = esc_html($attrs['text'] ?? '');
+		return '<div class="stub-component">' . $text . '</div>';
+	}
+
+	public function allowedHtmlTags(): array
+	{
+		return [];
+	}
+}


### PR DESCRIPTION
## Summary
Re-introduces the smart components foundation and media embed feature originally added in PR #200, after it was reverted in PR #205.

The implementation is complete and functional — the WordPress plugin correctly processes all components that PCC delivers. However, PCC's content parser has reliability issues that need to be resolved before this can ship.

## Known issues (PCC backend)
- **Intermittent component dropping**: PCC's content parser sometimes omits `<component>` placeholders from TREE_PANTHEON_V2 content. A document with 4 media embeds may only have 2 delivered.
- **Inline components lost**: Components placed inline within paragraph text are more likely to be dropped than those on their own line.
- **Component URL corruption**: Component attributes can arrive with incorrect data (e.g. the site URL instead of the configured video URL).
- **Inconsistent behavior**: The same document may work correctly on one publish and fail on the next, with no changes to the WordPress plugin or PCC configuration.

## What's included
- `SmartComponents` registry and processing pipeline
- `ComponentEndpoints` (`/component_schema`, `/component/{id}` preview)
- `MediaEmbed` component with oEmbed rendering
- `SmartComponentInterface` for third-party component registration
- Dual-fetch approach: TREE_PANTHEON_V2 for styled HTML + raw content for component metadata
- `savePost()`/`getSavingPostId()` for kses tag allowlisting in webhook context
- Smart component handling in `pcc-front.js` live preview
- Full test suite

## Do not merge until
- [ ] PCC content parser reliably includes all `<component>` placeholders
- [ ] Component count matches between raw content and TREE_PANTHEON_V2
- [ ] Component attributes are delivered without corruption
- [ ] Tested with documents containing multiple inline media embeds

Original work by @mklasen and @anaisgueyte in PR #200.