### PR TITLE
fix: [SITE-5202] PHP 8.5 compatibility - explicit nullable parameter

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -80,6 +80,7 @@ Yes. When creating or editing a collection, select the target post type from the
 == Changelog ==
 
 = 1.4.0-dev =
+* Compatibility: Supports PHP 8.5
 
 = 1.3.5 (5 March 2026) =
 * Feature: ACF integration — sync Content Publisher metadata fields to Advanced Custom Fields with per-post-type mappings [#201](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/pull/201)

--- a/app/PccSiteManager.php
+++ b/app/PccSiteManager.php
@@ -59,7 +59,7 @@ class PccSiteManager
 	/**
 	 * @return array[]
 	 */
-	private function getHeaders(string $token = null)
+	private function getHeaders(?string $token = null)
 	{
 		return [
 			'Content-Type' => 'application/json',


### PR DESCRIPTION
## Summary

- Fix implicitly nullable parameter deprecation in `PccSiteManager::getHeaders()` for PHP 8.5 compatibility

## Context

[SITE-5202](https://getpantheon.atlassian.net/browse/SITE-5202)

PHP 8.5 deprecates implicitly nullable parameters (`string $token = null`). Changed to explicit nullable syntax (`?string $token = null`).

CI already tests PHP 8.5 in the matrix (8.1, 8.2, 8.3, 8.4, 8.5). PHPCompatibility scan (8.5-) passes. This was caught by PHP 8.5 runtime lint, not static analysis.

## Test plan

- [x] CI passes on all PHP versions
- [x] PHPCompatibility check passes

[SITE-5202]: https://getpantheon.atlassian.net/browse/SITE-5202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ