### PR TITLE
[SITE-6002] Fix CodeQL alerts

### DIFF
--- a/.github/workflows/php-style-lint.yml
+++ b/.github/workflows/php-style-lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   build_app:
     name: "PHPCS"

--- a/.github/workflows/php-version-compatibility.yml
+++ b/.github/workflows/php-version-compatibility.yml
@@ -4,15 +4,18 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   php8-compatibility:
     name: PHP 8.x Compatibility
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: PHP Compatibility
-        uses: pantheon-systems/phpcompatibility-action@dev
+        uses: pantheon-systems/phpcompatibility-action@bd72eb001d4fb9817c9d6e1a157a71e287f3ff80 # dev
         with:
           test-versions: 8.0-
           paths: ${{ github.workspace }}/*.php ${{ github.workspace }}/app/*.php ${{ github.workspace }}/admin/templates/partials/*.php

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,9 +13,9 @@ jobs:
     name: Draft Release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create Draft Release PR
-        uses: pantheon-systems/plugin-release-actions/release-pr@main
+        uses: pantheon-systems/plugin-release-actions/release-pr@b1c7493f44edb8d0053515b4551a80112b5376c0 # main
         with:
           gh_token: ${{ github.token }}
           readme_md: README.md

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -3,15 +3,18 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     # Do not run this job for prerelease versions.
     if: ${{ ! github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@2.3.0
+      uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
## Summary

Fixes all 6 open CodeQL security alerts by hardening GitHub Actions workflow configurations.

**Missing workflow permissions (alerts #2, #20, #21):** Added explicit `permissions:` blocks with least-privilege scopes to three workflows that relied on default (overly broad) token permissions:
- `php-style-lint.yml` - `contents: read`
- `php-version-compatibility.yml` - `contents: read`
- `wordpress-plugin-deploy.yml` - `contents: read`

`release-pr.yml` already had explicit permissions (`contents: write`, `pull-requests: write`).

**Unpinned action tags (alerts #3, #15, #17):** Replaced mutable tag/branch references with immutable SHA pins across all four workflows. Each pinned reference includes a version comment for readability:
- `actions/checkout@v6.0.2` -> `de0fac2e4500dabe0009e67214ff5f5447ce83dd`
- `pantheon-systems/phpcompatibility-action@dev` -> `bd72eb001d4fb9817c9d6e1a157a71e287f3ff80`
- `10up/action-wordpress-plugin-deploy@2.3.0` -> `54bd289b8525fd23a5c365ec369185f2966529c2`
- `pantheon-systems/plugin-release-actions/release-pr@main` -> `b1c7493f44edb8d0053515b4551a80112b5376c0`

## Test plan

- [ ] Verify CodeQL alerts close after merge
- [ ] Confirm existing workflows still trigger and run correctly (PR checks, release deploy, release PR)