### PR TITLE
fix(VUL-24137): bump postcss from 8.5.6 to 8.5.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9293,9 +9293,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -9303,6 +9303,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -10230,9 +10231,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -10248,8 +10249,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "laravel-mix": "^6.0.49",
     "net": "^1.0.2",
     "node-polyfill-webpack-plugin": "^4.0.0",
-    "postcss": "^8.4.38",
+    "postcss": "^8.5.10",
     "postcss-cli": "^11.0.0",
     "postcss-prefix-selector": "^1.16.1",
     "postcss-prefixer": "^3.0.0",


### PR DESCRIPTION
## Summary

Bumps `postcss` from **8.5.6** to **8.5.19** to address a medium-severity XSS vulnerability.

Addresses Jira ticket: [VUL-24137](https://getpantheon.atlassian.net/browse/VUL-24137) [VUL-24138](https://getpantheon.atlassian.net/browse/VUL-24138)

## CVE Table

| Package | CVE | Severity | Description | Fixed In |
|---------|-----|----------|-------------|----------|
| postcss | [CVE-2026-41305](https://nvd.nist.gov/vuln/detail/CVE-2026-41305) | Medium | XSS via unescaped `</style>` in CSS Stringify output (CWE-79) | 8.5.10 |

## Changes

- **`package.json`**: Updated `postcss` devDependency range from `^8.4.38` to `^8.5.10` to ensure future installs resolve to a patched version.
- **`package-lock.json`**: Updated resolved postcss version from `8.5.6` to `8.5.19` (the latest available patch in the 8.x line).

`postcss` is a direct devDependency used for CSS processing. The manifest pin was updated alongside the lockfile to prevent regressions on fresh installs.

[VUL-24137]: https://getpantheon.atlassian.net/browse/VUL-24137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VUL-24138]: https://getpantheon.atlassian.net/browse/VUL-24138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ