### PR TITLE
fix(VUL-24138): bump websocket-driver from 0.7.4 to 0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14109,9 +14109,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Summary

Bumps the transitive dependency `websocket-driver` from `0.7.4` to `0.7.5` in the lockfile to address a critical CVE.

Addresses: [VUL-24138](https://getpantheon.atlassian.net/browse/VUL-24138)

## CVEs Addressed

| Package | CVE | Severity | Description | Fixed In |
|---|---|---|---|---|
| websocket-driver | [CVE-2026-54466](https://nvd.nist.gov/vuln/detail/CVE-2026-54466) | Critical | Message corruption via abuse of protocol length headers (CWE-130) | 0.7.5 |

## Changes

- **package-lock.json** — updated `websocket-driver` from `0.7.4` to `0.7.5`. This is a transitive dependency (pulled in by `sockjs`); it does not appear in `package.json`, so only the lockfile was changed. Promoting a transitive dep to a direct dep would be incorrect.

[VUL-24138]: https://getpantheon.atlassian.net/browse/VUL-24138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ