### PR TITLE
fix(VUL-25019): bump fast-uri from 3.0.1 to 3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "laravel-mix": "^6.0.49",
         "net": "^1.0.2",
         "node-polyfill-webpack-plugin": "^4.0.0",
-        "postcss": "^8.4.38",
+        "postcss": "^8.5.10",
         "postcss-cli": "^11.0.0",
         "postcss-prefix-selector": "^1.16.1",
         "postcss-prefixer": "^3.0.0",
@@ -6977,11 +6977,21 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
-      "license": "MIT"
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",


### PR DESCRIPTION
## Summary

Bumps the transitive dev dependency `fast-uri` from `3.0.1` to `3.1.4` to address CVE-2026-13676.

Jira ticket: [VUL-25019](https://getpantheon.atlassian.net/browse/VUL-25019)

## CVE Table

| Package | CVE | Severity | Description | Fixed In |
|---------|-----|----------|-------------|----------|
| fast-uri | [CVE-2026-13676](https://nvd.nist.gov/vuln/detail/CVE-2026-13676) | High | fast-uri vulnerable to host confusion via failed IDN canonicalization | 3.1.3 |

## Changes

- **`package-lock.json`** — `fast-uri` bumped from `3.0.1` to `3.1.4` via `npm update fast-uri`.

`fast-uri` is a **transitive dev dependency** only — it is pulled in by nested `ajv` instances inside `ajv-formats`, `webpack-dev-middleware`, and `webpack-dev-server`. It is not a direct dependency and does not appear in `package.json`. The lockfile is the only file changed.

## CVE Attribution

The advisory (GHSA-4c8g-83qw-93j6) covers three ranges:
- `>= 4.0.0, < 4.0.1` — patched by 4.0.1
- `>= 3.0.0, < 3.1.3` — patched by 3.1.3
- `>= 2.3.1, < 2.4.2` — patched by 2.4.2

The repo had `3.0.1` which falls in the second range. Bumping to `3.1.4` (≥ 3.1.3) resolves it.

[VUL-25019]: https://getpantheon.atlassian.net/browse/VUL-25019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ