### PR TITLE
fix(VUL-25451): bump immutable from 4.3.7 to 4.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8188,9 +8188,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary

Bumps the transitive npm dependency `immutable` from 4.3.7 to 4.3.9 to resolve a high-severity denial-of-service vulnerability.

Addresses: [VUL-25451](https://getpantheon.atlassian.net/browse/VUL-25451)

## CVE Table

| Package | CVE | Severity | Description | Fixed In |
|---|---|---|---|---|
| immutable | [CVE-2026-59880](https://nvd.nist.gov/vuln/detail/CVE-2026-59880) | High | Hash-collision algorithmic complexity denial of service in Immutable.Map/Set (CWE-400, CWE-407) | 4.3.9 |

## Changes

`immutable` is a transitive dependency brought in by `sass` (a dev dependency). It is not imported directly by any source files in this repo. Only `package-lock.json` was modified — no change to `package.json` since this is not a direct dependency.

The fix pins `node_modules/immutable` to 4.3.9 in the lockfile. `sass@1.77.8` declares `immutable: ^4.0.0`, so 4.3.9 satisfies its constraint without requiring a `sass` upgrade.

## CVE Attribution

CVE-2026-59880 affects `immutable` < 4.3.9 via algorithmic complexity in hash operations on `Map` and `Set` objects. While `immutable` is used by `sass` (a build-time dev dep), compliance policy requires the lockfile to resolve to a patched version.

## Risk Assessment

**Low** — lockfile-only bump of a dev transitive dependency not imported by any production source; package cannot regress runtime behavior.

| Layer | Score | Evidence |
|---|---|---|
| Pre-merge detection | partial | PHP unit test suite (3 test files) runs on PRs; no JS/TS tests found |
| Deployment safety | unknown | no deploy config in repo (WordPress plugin published via wp.org deploy workflow) |
| Production detection | unknown | no metrics/alerting config found in repo |
| Recovery speed | strong | release-please automation, 6+ releases in last 12 months |

Bump: `immutable` 4.3.7 → 4.3.9 (patch). Short-circuit applied: package is lockfile-only (dev transitive dep), not imported by repo source — regression risk is negligible.

[VUL-25451]: https://getpantheon.atlassian.net/browse/VUL-25451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ