### PR TITLE
[SITE-6065] Prepare 1.3.6-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** pantheon, content, google docs, acf  
 **Requires at least:** 6.5  
 **Tested up to:** 7.0  
-**Stable tag:** 1.4.0-dev  
+**Stable tag:** 1.3.6-dev  
 **Requires PHP:** 8.1.0  
 **License:** GPLv2 or later  
 **License URI:** <http://www.gnu.org/licenses/gpl-2.0.html>

--- a/README.txt
+++ b/README.txt
@@ -81,8 +81,8 @@ Yes. When creating or editing a collection, select the target post type from the
 
 = 1.3.6-dev =
 * Compatibility: Supports PHP 8.5 (#217)
-* Tested up to WordPress 7.0
-* Updated npm and Composer dependencies (#221, #231, #232, #233, #236)
+* Compatibility: Supports WordPress 7.0
+* Fix: Updated npm and Composer dependencies (#221, #231, #232, #233, #236)
 
 = 1.3.5 (5 March 2026) =
 * Feature: ACF integration — sync Content Publisher metadata fields to Advanced Custom Fields with per-post-type mappings [#201](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/pull/201)

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, a11rew, anaispantheor, roshnykunjappan, mklasen, jazz
 Tags: pantheon, acf, google docs
 Requires at least: 6.5
 Tested up to: 7.0
-Stable tag: 1.4.0-dev
+Stable tag: 1.3.6-dev
 Requires PHP: 8.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,8 +79,10 @@ Yes. When creating or editing a collection, select the target post type from the
 
 == Changelog ==
 
-= 1.4.0-dev =
-* Compatibility: Supports PHP 8.5
+= 1.3.6-dev =
+* Compatibility: Supports PHP 8.5 (#217)
+* Tested up to WordPress 7.0 (#223)
+* Updated npm and Composer dependencies (#221, #231, #232, #233, #236)
 
 = 1.3.5 (5 March 2026) =
 * Feature: ACF integration — sync Content Publisher metadata fields to Advanced Custom Fields with per-post-type mappings [#201](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/pull/201)

--- a/README.txt
+++ b/README.txt
@@ -81,7 +81,7 @@ Yes. When creating or editing a collection, select the target post type from the
 
 = 1.3.6-dev =
 * Compatibility: Supports PHP 8.5 (#217)
-* Tested up to WordPress 7.0 (#223)
+* Tested up to WordPress 7.0
 * Updated npm and Composer dependencies (#221, #231, #232, #233, #236)
 
 = 1.3.5 (5 March 2026) =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pantheon-content-publisher",
-  "version": "1.4.0-dev",
+  "version": "1.3.6-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pantheon-content-publisher",
-      "version": "1.4.0-dev",
+      "version": "1.3.6-dev",
       "dependencies": {
         "@pantheon-systems/pcc-sdk-core": "3.11.3",
         "@pantheon-systems/pds-toolkit-react": "1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pantheon-content-publisher",
-  "version": "1.4.0-dev",
+  "version": "1.3.6-dev",
   "description": "Publish WordPress content from Google Docs with Pantheon Content Cloud.",
   "scripts": {
     "dev": "NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --config=node_modules/laravel-mix/setup/webpack.config.js",

--- a/pantheon-content-publisher.php
+++ b/pantheon-content-publisher.php
@@ -8,7 +8,7 @@
  * Plugin URI: https://wordpress.org/plugins/pantheon-content-publisher/
  * Author: Pantheon
  * Author URI: https://pantheon.io
- * Version: 1.4.0-dev
+ * Version: 1.3.6-dev
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
@@ -37,7 +37,7 @@ define('CPUB_WEBHOOK_SECRET_OPTION_KEY', 'cpub_webhook_secret');
 define('CPUB_WEBHOOK_NOTICE_DISMISSED_OPTION_KEY', 'cpub_webhook_notice_dismissed');
 define('CPUB_ACF_FIELD_MAPPINGS_OPTION_KEY', 'cpub_acf_field_mappings');
 define('CPUB_ACF_USER_MATCH_BY_OPTION_KEY', 'cpub_acf_user_match_by');
-define('CPUB_VERSION', '1.4.0-dev');
+define('CPUB_VERSION', '1.3.6-dev');
 
 call_user_func(static function ($rootPath) {
 	$autoload = "{$rootPath}vendor/autoload.php";


### PR DESCRIPTION
## Summary

- Updated version from 1.4.0-dev to 1.3.6-dev — all commits since 1.3.5 are fixes and dependency updates, no new features warranting a minor version bump ( The  1.4.0 bump was originally planned for the video embed feature (SITE-5421, PR #206), but that hasn't landed yet)
- Updates changelog with 1.3.6 entries

## Changelog

- Compatibility: Supports PHP 8.5 (#217)
- Tested up to WordPress 7.0 
- Updated npm and Composer dependencies (#221, #231, #232, #233, #236)

## Context

[SITE-6065](https://getpantheon.atlassian.net/browse/SITE-6065)

[SITE-6065]: https://getpantheon.atlassian.net/browse/SITE-6065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ